### PR TITLE
Rework Docker Image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,11 +1,11 @@
 name: Build image
 
 on:
-  push:
-    branches:
-      - master
-  schedule:
-    - cron: '0 1 * * 1' # Weelky on a Monday
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Latest version of Cloudlog to build'
+        required: true
 
 jobs:
   build_and_push:
@@ -18,41 +18,36 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            neilbartley/cloudlog
-            ghcr.io/neilbartley/cloudlog
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate Docker image timestamp tag
-        id: image-tag
-        run: echo "::set-output name=timestamp::$(date +'%Y%m%d%H%M%S')"
-
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: RELEASE_VERSION=${{ github.event.inputs.release_version }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             neilbartley/cloudlog:latest
-            neilbartley/cloudlog:${{ steps.image-tag.outputs.timestamp }}
+            neilbartley/cloudlog:${{ github.event.inputs.release_version }}
             ghcr.io/neilbartley/cloudlog:latest
-            ghcr.io/neilbartley/cloudlog:${{ steps.image-tag.outputs.timestamp }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ghcr.io/neilbartley/cloudlog:${{ github.event.inputs.release_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,21 @@
-FROM 2m0sql/cloudlog:latest
+####################################################################################################
+# Imaege to unpack the Cloudlog release tarball.
+####################################################################################################
+FROM debian:12-slim AS release-unpacker
+
+ARG RELEASE_VERSION
+ADD https://github.com/magicbug/Cloudlog/archive/refs/tags/${RELEASE_VERSION}.tar.gz /
+
+WORKDIR /cloudlog-release
+RUN tar zxzf /${RELEASE_VERSION}.tar.gz --strip-components=1
+
+####################################################################################################
+# Main image build.
+#
+# Some of this was taken from the original Cloudlog Dockerfile which was removed
+# here: https://github.com/magicbug/Cloudlog/commit/46652555073ef0b26ff6c2b46f41db05d340c1d7
+####################################################################################################
+FROM php:8.2-apache
 
 ENV LOCATOR set_me
 ENV BASE_URL set_me
@@ -16,7 +33,20 @@ ENV DEVELOPER_MODE set_me
 ENV DATABASE_IS_MARIADB set_me
 ENV CLOUDLOG_LOGGING set_me
 
+RUN apt-get update && \
+    apt-get install -y git curl libxml2-dev libonig-dev && \
+    docker-php-ext-install mysqli mbstring xml && \
+    rm -rf /var/www/html/docker/ /var/lib/apt/lists/* && \
+    echo "file_uploads = On" >> /usr/local/etc/php/conf.d/uploads.ini && \
+    echo "memory_limit = 64M" >> /usr/local/etc/php/conf.d/uploads.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/uploads.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/uploads.ini && \
+    echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/uploads.ini
+
 COPY entrypoint.sh /
+
+WORKDIR /var/www/html
+COPY --from=release-unpacker /cloudlog-release/ ./
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apachectl", "-D", "FOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
 # Cloudlog Docker Image
 
-This extends the `2m0sql/cloudlog:latest` image to add an entrypoint which updates the configuration file based on environment variables at the start of each run. It will be available as `neilbartley/cloudlog` at:
+This resurrects the [now defunct](https://github.com/magicbug/Cloudlog/commit/46652555073ef0b26ff6c2b46f41db05d340c1d7) offical Cloudlog Docker image and combines it with my modification to allow configuration to be defined at runtime (either via `docker-compose.yml` or `docker run`) and make the container in which this runs disposable.
 
-* [Docker Hub (`neilbartley/cloudlog:latest`)](https://hub.docker.com/r/neilbartley/cloudlog)
+The images will be tagged with the Cloudlog version and available from:
+
 * [GitHub (`ghcr.io/neilbartley/cloudlog:latest`)](https://github.com/neilbartley/ysfreflector/pkgs/container/cloudlog)
+* [Docker Hub (`neilbartley/cloudlog:latest`)](https://hub.docker.com/r/neilbartley/cloudlog)
 
 ## Donations
 
 Please consider either paying for [magicbug to host your cloudlog](https://github.com/magicbug/Cloudlog#want-cloudlog-hosting) or donating [here](https://github.com/magicbug/Cloudlog#patreons--donors).
-
-# Running
-
-## Requirements
-
-* [Docker](https://docs.docker.com/install/)
-* Firewall setup to accept `80/tcp`
-* MySQL database setup (see [here](https://github.com/magicbug/Cloudlog/wiki/Installation#4-create-a-sql-database-and-user))
 
 ## Usage
 
@@ -36,24 +30,46 @@ These environment variables are optional:
 * `DEVELOPER_MODE`
 * `DATABASE_IS_MARIADB`
 
-Example:
+### Example: `docker run`
 
 ```
 docker run \
-  -e LOCATOR="IO94XX" \
-  -e BASE_URL="http://log.m0abc.com/" \
-  -e DATABASE_HOSTNAME="localhost" \
-  -e DATABASE_NAME="m0abc_log" \
-  -e DATABASE_USERNAME="m0abc" \
-  -e DATABASE_PASSWORD="supersecret" \
+  -e BASE_URL="http://log.m9abc.com/" \
   -e CALLBOOK="hamqth" \
-  -e CALLBOOK_USERNAME="m0abc" \
   -e CALLBOOK_PASSWORD="supersecret" \
-  -e DEVELOPER_MODE="no" \
+  -e CALLBOOK_USERNAME="m9abc" \
+  -e DATABASE_HOSTNAME="localhost" \
   -e DATABASE_IS_MARIADB="yes" \
-  -p 80:80/tcp \
+  -e DATABASE_NAME="m9abc_log" \
+  -e DATABASE_PASSWORD="supersecret" \
+  -e DATABASE_USERNAME="m9abc" \
+  -e DEVELOPER_MODE="no" \
+  -e LOCATOR="IO94XX" \
+  ...
   -name=cloudlog \
   ghcr.io/neilbartley/cloudlog:latest
+```
+
+### Example: `docker compose`
+
+```
+  cloudlog:
+    container_name: cloudlog
+    image: ghcr.io/neilbartley/cloudlog:latest
+    restart: unless-stopped
+    environment:
+      BASE_URL: "https://log.m9abc.uk/"
+      CALLBOOK: "hamqth"
+      CALLBOOK_PASSWORD: "supersecret"
+      CALLBOOK_USERNAME: "m9abc"
+      DATABASE_HOSTNAME: "mariadb"
+      DATABASE_IS_MARIADB: "yes"
+      DATABASE_NAME: "m9abc_log"
+      DATABASE_PASSWORD: "supersecret"
+      DATABASE_USERNAME: "m9abc"
+      DEVELOPER_MODE: "no"
+      LOCATOR: "IO94ER"
+    ...
 ```
 
 73, G7UFO

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# This script is run when the container starts and is responsible for creeating the Cloudlog database
+# and application config file amongst a few other things. Everything is commented.
+#
+# If there are any upstream changes to these files this might break. Open an issue on GitHub if I've
+# not already fixed!
+
 # Ensure required env vars are set
 ENV_VAR_REQUIRED='LOCATOR BASE_URL DATABASE_HOSTNAME DATABASE_NAME DATABASE_USERNAME DATABASE_PASSWORD'
 for ENV_VAR in ${ENV_VAR_REQUIRED}; do


### PR DESCRIPTION
Lots of updates:

- Use official image as basis of app `Dockerfile`.
- Add multi-stage build to first pull the release from Cloudlog.
- Update readme.
- Update GitHub Action:
   - Update action versions
   - Build multi platform
   - Be triggered manually (until I figure out a nice way of tracking Cloudlog releases automatically)
 